### PR TITLE
future proof  linkValidator.js

### DIFF
--- a/scripts/linkValidator.js
+++ b/scripts/linkValidator.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
  * usage:
  * note: Windows path separator used below! (to avoid error with parsing of this comment block)


### PR DESCRIPTION
1. make it obvious that variables need to be declared before use
2. Keywords reserved for future JavaScript versions can NOT be used as variable names in strict mode