### PR TITLE
Fix for code scanning alert - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@
 # - links: scripts/linkValidator.js
 # - makrdown: .markdownlint.jsonc
 name: Lint
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.ref }}-lint


### PR DESCRIPTION
Fix for [https://github.com/mi-hol/fome-wiki/security/code-scanning/4](https://github.com/mi-hol/fome-wiki/security/code-scanning/4)

To fix the problem, the workflow YAML must explicitly restrict the permissions for the GITHUB_TOKEN by adding a `permissions` key. The best solution is to add `permissions: contents: read` at the top level of the workflow (directly under `name: Lint` and above `concurrency:`), which will apply these least-privilege permissions to all jobs in the workflow. This approach ensures no job acquires permission to write to the repository unnecessarily and improves CI safety. No imports or external changes are needed; it's a strict YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
